### PR TITLE
fixes spidev "too many files" issue

### DIFF
--- a/e-paper/rpi/python/lib/waveshare_epd/epd7in5_V2.py
+++ b/e-paper/rpi/python/lib/waveshare_epd/epd7in5_V2.py
@@ -164,6 +164,8 @@ class EPD:
         
         self.send_command(0x07) # DEEP_SLEEP
         self.send_data(0XA5)
+
+        epdconfig.module_sleep()
         
     def Dev_exit(self):
         epdconfig.module_exit()

--- a/e-paper/rpi/python/lib/waveshare_epd/epdconfig.py
+++ b/e-paper/rpi/python/lib/waveshare_epd/epdconfig.py
@@ -73,6 +73,9 @@ class RaspberryPi:
         self.SPI.mode = 0b00
         return 0
 
+    def module_sleep(self):
+        self.SPI.close()
+
     def module_exit(self):
         logging.debug("spi end")
         self.SPI.close()


### PR DESCRIPTION
After running a while (depending on update frequency) the program eventually crashes with a __to many open files__ error. This error is a direct consequence of the fix for the ```epd.sleep()``` functionality. The order of events that leads to this is as follows: 

1. The initial starting of the program initializes the EPD driver, this causes an instance of ```self.SPI = spidev.SpiDev()``` to be created. 
2. Every run of the program calls ```epd.init()```, which initializes the SPI interface with a call to ```self.SPI.open(0, 0)```
3. SlowMovie calls ```epd.sleep()``` to enter the low power mode
4. After the sleep duration calls ```epd.init()``` again, creating another call to ```self.SPI.open(0, 0)```. 

These repeated calls to the ```open()``` function accumulate open file handles that never get closed. This can be verified with a call to ```sudo ls -l /proc/{PID}/fd``` (where PID is the process ID of your python instance) from an SSH session. Eventually this hits the system max and errors out the program. 

__The Patch__

This patch attempts to fix this by adding a call to ```self.SPI.close()``` when the ```epd.sleep()``` method is called. This shouldn't hurt performance (much) as the ```init()``` method is called at the start of each screen update anyway. This will ensure that any open file handles get closed prior to entering the sleep function. I also added a method ```module_sleep()``` to the ```epdconfig.py``` class as I thought this was better for class encapsulation than calling the SPI object directly from the driver class. This also makes it a bit more adaptable should other drivers need this fix (as I imagine they do). 

I did verify this on my own running version by letting the screen update for over 24 hrs. No open files from SpiDev existed and no crashes. 