### PR TITLE
Add .mkv support

### DIFF
--- a/slowmovie.py
+++ b/slowmovie.py
@@ -72,6 +72,7 @@ def video_info(file):
     stream = probeInfo['streams'][0]
 
     # Calculate framerate
+    r_fps = stream['r_frame_rate']
     fps = float(Fraction(r_fps))
 
     # Calculate duration
@@ -123,7 +124,7 @@ if not os.path.isdir(viddir):
 # First we try the file argument...
 currentVideo = args.file
 
-# ...then a random video, if selected... 
+# ...then a random video, if selected...
 if not currentVideo and args.random_file:
     videos = list(filter(supported_filetype, os.listdir(viddir)))
     if videos:

--- a/slowmovie.py
+++ b/slowmovie.py
@@ -54,7 +54,7 @@ def check_vid(value):
     if not os.path.isfile(value):
         raise configargparse.ArgumentTypeError("File '%s' does not exist" % value)
     if not supported_filetype(value):
-        raise argparse.ArgumentTypeError(f"File '{file}' should be a file with one of the following supported extensions: {', '.join(fileTypes)}")
+        raise configargparse.ArgumentTypeError(f"File '{file}' should be a file with one of the following supported extensions: {', '.join(fileTypes)}")
     return value
 
 def check_dir(value):

--- a/slowmovie.py
+++ b/slowmovie.py
@@ -50,11 +50,11 @@ def generate_frame(in_filename, out_filename, time):
         .run(capture_stdout=True, capture_stderr=True)
     )
 
-def check_mp4(value):
+def check_vid(value):
     if not os.path.isfile(value):
         raise configargparse.ArgumentTypeError("File '%s' does not exist" % value)
     if not supported_filetype(value):
-        raise configargparse.ArgumentTypeError("'%s' is not a supported file type" % value)
+        raise argparse.ArgumentTypeError(f"File '{file}' should be a file with one of the following supported extensions: {', '.join(fileTypes)}")
     return value
 
 def check_dir(value):
@@ -68,17 +68,36 @@ def supported_filetype(file):
     return ext.lower() in fileTypes
 
 def video_info(file):
-    videoInfo = ffmpeg.probe(file)
-    frameCount = int(videoInfo["streams"][0]["nb_frames"])
-    framerate = videoInfo["streams"][0]["avg_frame_rate"]
-    framerate = float(Fraction(framerate))
-    frametime = 1000 / framerate
-    return frameCount, framerate, frametime
+    probeInfo = ffmpeg.probe(file)
+    stream = probeInfo['streams'][0]
+
+    # Calculate framerate
+    fps = float(Fraction(r_fps))
+
+    # Calculate duration
+    duration = float(probeInfo['format']['duration'])
+
+    # Either get frame count or calculate it
+    try:
+        # Get frame count for .mp4s
+        frameCount = int(stream['nb_frames'])
+    except KeyError:
+        # Calculate frame count for .mkvs (and maybe other formats?)
+        frameCount = int(duration * fps)
+
+    # Calculate frametime (ms each frame is displayed)
+    frameTime = 1000 / fps
+
+    return {
+        'frame_count' : frameCount,
+        'fps' : fps,
+        'duration' : duration,
+        'frame_time' : frameTime }
 
 os.chdir(os.path.dirname(os.path.realpath(__file__)))
 
 parser = configargparse.ArgumentParser(default_config_files=["slowmovie.conf"])
-parser.add_argument("-f", "--file", type = check_mp4, help = "Specify an MP4 file to play")
+parser.add_argument("-f", "--file", type = check_vid, help = "video file to start playing")
 parser.add_argument("-R", "--random-file", action = "store_true", help = "Play files in random order")
 parser.add_argument("-r", "--random", action = "store_true", help = "Display random frames")
 parser.add_argument("-D", "--dir", default = "Videos", type = check_dir, help = "Select video directory")
@@ -152,18 +171,18 @@ epd = epd_driver.EPD()
 width = epd.width
 height = epd.height
 
-frameCount, framerate, frametime = video_info(currentVideo)
+videoInfo = video_info(currentVideo)
 
 if not args.random:
     if args.start:
-        currentFrame = clamp(args.start, 0, frameCount)
+        currentFrame = clamp(args.start, 0, videoInfo['frame_count'])
         print("Starting at frame " + str(currentFrame))
     elif (os.path.isfile(logfile)):
         # Read current frame from logfile
         with open(logfile) as log:
             try:
                 currentFrame = int(log.readline())
-                currentFrame = clamp(currentFrame, 0, frameCount)
+                currentFrame = clamp(currentFrame, 0, videoInfo['frame_count'])
             except ValueError:
                 currentFrame = 0
     else:
@@ -174,15 +193,16 @@ lastVideo = None
 while 1:
     if lastVideo != currentVideo:
         print(f"Playing '{videoFilename}'")
+        print(f'Video info: {videoInfo["frame_count"]} frames, {videoInfo["fps"]:.3f}fps, duration: {videoInfo["duration"]}s')
         lastVideo = currentVideo
 
     timeStart = time.perf_counter()
     epd.init()
 
     if args.random:
-        currentFrame = random.randint(0, frameCount)
+        currentFrame = random.randint(0, videoInfo["frame_count"])
 
-    msTimecode = "%dms" % (currentFrame * frametime)
+    msTimecode = "%dms" % (currentFrame * videoInfo["frame_time"])
 
     # Use ffmpeg to extract a frame from the movie, letterbox/pillarbox it and save it as frame.bmp
     generate_frame(currentVideo, "/dev/shm/frame.bmp", msTimecode)
@@ -198,12 +218,12 @@ while 1:
     #pil_im = pil_im.convert(mode = "1", dither = Image.FLOYDSTEINBERG)
 
     # display the image
-    print(f"Displaying frame {currentFrame} of '{videoFilename}'")
+    print(f'Displaying frame {int(currentFrame)} of {videoFilename} ({(currentFrame/videoInfo["frame_count"])*100:.1f}%)')
     epd.display(epd.getbuffer(pil_im))
 
     if not args.random:
         currentFrame += args.increment
-        if currentFrame > frameCount:
+        if currentFrame > videoInfo['frame_count']:
             # end of video
             if not args.loop:
                 if args.random_file:
@@ -223,7 +243,7 @@ while 1:
                     file.write(os.path.abspath(currentVideo))
 
                 logfile = os.path.join(logdir, videoFilename + ".progress")
-                frameCount, framerate, frametime = video_info(currentVideo)
+                videoInfo = video_info(currentVideo)
 
             currentFrame = 0
 


### PR DESCRIPTION
* Changes video_info function to return an dictionary.
* Get framerate and frame count in a more robust way from the ffmpeg 
probe. This method works for the mkv I was testing on.
* The dictionary returned from video_info now includes duration, setting 
up for future runtime estimates.

Hopefully equivalent to f450a90, baa0526, and 8f0c58a