### PR TITLE
Review Process Flow

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Pull requests are the best way to propose changes to the codebase (we use [Githu
 3. Submit that pull request! Be sure to include relevant information per the PR template. 
 
 ### Review Process
-Once submitted your PR will get reviewed - be patient. Depending on the complexity of the change it may take some time and even some back and forth to get things all squared away. You may even be asked to change something, it's all part of the process. 
+Once submitted your PR will get reviewed - be patient. All Pull Requests require at least one review from someone with Maintainer access to the repository. For larger changes that modify base functionality multiple reviewers may be necessary so all stakeholders have a chance to test the changes. It may take some time and back and forth to get things all squared away. You may even be asked to change something, it's all part of the process.
 
 Once everything looks good your PR will be merged!
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -42,7 +42,12 @@ Pull requests are the best way to propose changes to the codebase (we use [Githu
 3. Submit that pull request! Be sure to include relevant information per the PR template. 
 
 ### Review Process
-Once submitted your PR will get reviewed - be patient. All Pull Requests require at least one review from someone with Maintainer access to the repository. For larger changes that modify base functionality multiple reviewers may be necessary so all stakeholders have a chance to test the changes. It may take some time and back and forth to get things all squared away. You may even be asked to change something, it's all part of the process.
+Once submitted your PR will get reviewed - be patient.
+
+* All pull requests require at least one approval review from a maintainer before being merged.
+* For larger changes that modify base functionality, multiple reviewers should test and discuss the changes before merging the PR.
+
+It may take some time and back and forth to get things all squared away. You may even be asked to change something, it's all part of the process.
 
 Once everything looks good your PR will be merged!
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -41,6 +41,17 @@ Pull requests are the best way to propose changes to the codebase (we use [Githu
 2. If you've changed functionality or dependencies, update the documentation.
 3. Submit that pull request! Be sure to include relevant information per the PR template. 
 
+
+### Coding Standards
+For code consistancy we try our best to adhere to the [PEP8](https://www.python.org/dev/peps/pep-0008/) guide. This makes sure everything looks cohesive regardless of who did the actually coding. All PRs will automatically be checked before review or merging. Don't let this scare you from contributing! These are often minor changes and Maintainers can help if this is a sticking point. 
+
+Before submitting a PR you can check your code yourself by installing [Flake8](https://flake8.pycqa.org/en/latest/) and running a simple command.
+
+```
+pip3 install flake8
+flake8 --ignore E501 slowmovie.py
+```
+
 ### Review Process
 Once submitted your PR will get reviewed - be patient.
 


### PR DESCRIPTION
Based on the flow we've kind of started I wanted to capture it as part of the contributing file. The basic idea is that for simple PRs at least one additional review (other than the PR author) are needed before merging in. This should make easy things like documentation and syntax updates quick to get approved and merged in. For larger updates that touch functionality we'll want to get more input and testing of the code. 

There are some settings in GitHub we can turn on to enforce this kind of flow but we'd need Tom to turn them on as only a full repo Admin has access to them. If it's in writing at least there aren't any surprises when something is merged in or not merged in depending on what it touches. 

Feel free to wordsmith this, it's just a jumping off point. 

