### PR TITLE
Remember video info for each video

### DIFF
--- a/slowmovie.py
+++ b/slowmovie.py
@@ -105,13 +105,14 @@ def video_info(file):
         frameTime = 1000 / fps
 
         info = {
-            'frame_count' : frameCount,
-            'fps' : fps,
-            'duration' : duration,
-            'frame_time' : frameTime }    
+            'frame_count': frameCount,
+            'fps': fps,
+            'duration': duration,
+            'frame_time': frameTime}
 
         videoInfos[file] = info
     return info
+
 
 os.chdir(os.path.dirname(os.path.realpath(__file__)))
 


### PR DESCRIPTION
This is something I previously implemented in `helloworld.py`. 

The first time a given video is scanned, the results are added to a dict. Then, if the same file is encountered again, the video info is retrieved from the dict rather than running ffprobe again, which can take a few seconds on slower devices.

This'll be particularly useful if a "random frames from folder" mode is added (this is what `helloworld.py` does).