### PR TITLE
Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,13 +7,13 @@ assignees: ''
 
 ---
 
-Please fill in as much as you can, the more information the easier problems are to solve! 
+<!--- Please fill in as much as you can, the more information the easier problems are to solve! --->
 
 **Describe the problem**
-Be as specific as you can, include what should happen vs what is actually happening if it's a functionality issue. 
+<!--- Be as specific as you can, include what should happen vs what is actually happening if it's a functionality issue. --->
 
 **Steps to Reproduce**
-How can someone else recreate this? 
+<!--- How can someone else recreate this? --->
 
 **Platform Information** 
-(Raspberry Pi model, OS, Python version, anything useful)
+<!--- List your Raspberry Pi model, OS, Python version, and any other useful info) --->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,10 +8,10 @@ assignees: ''
 ---
 
 **Describe the problem**
-Problems should be inconsistencies with how things work or enhancements to the program. For error messages or things not working use a bug report. 
+<!--- Problems should be inconsistencies with how things work or enhancements to the program. For error messages or things not working use a bug report. --->
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+<!--- A clear and concise description of what you want to happen. --->
 
 **Describe alternatives you've considered**
-A clear and concise description of any alternative solutions that would also fix this issue.
+<!--- A clear and concise description of any alternative solutions that would also fix this issue. --->

--- a/.github/ISSUE_TEMPLATE/help.md
+++ b/.github/ISSUE_TEMPLATE/help.md
@@ -1,0 +1,16 @@
+---
+name: Help
+about: 'Need help setting up a VSMP?'
+title: ''
+labels: help
+assignees: ''
+
+---
+
+<!--- Please fill in as much as you can, the more information we have, the more we can help! --->
+
+**Describe the problem**
+<!--- Be as specific as you can, include what should happen vs what is actually happening if it's a functionality issue. --->
+
+**Platform Information** 
+<!--- List your Raspberry Pi model, OS, Python version, and any other useful info) --->

--- a/.github/ISSUE_TEMPLATE/informational.md
+++ b/.github/ISSUE_TEMPLATE/informational.md
@@ -7,4 +7,4 @@ assignees: ''
 
 ---
 
-Share any links or other information you think we need to know here. Be advised this will often get viewed and closed out.
+<!--- Share any links or other information you think we need to know here. Be advised this will often get viewed and closed out. --->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,8 +1,8 @@
 ---
-name: Help
+name: Question
 about: 'Need help setting up a VSMP?'
 title: ''
-labels: help
+labels: question
 assignees: ''
 
 ---


### PR DESCRIPTION
Inspired by #62 

1. adding comments so the instructions don't show in posted issues

2. adding `help` tag and issue template
    * My thought is, until we have a Wiki or something, people are probably going to post issues asking for help with various problems. Without a help option, they'll probably just get labeled as bugs even when they're not.
    * Maybe eventually we can use a Wiki for common problems and maybe even the new Discussions feature. Something we decide works well for this type of thing. Until then, I think this'll be good to have a place for this type of activity which we've seen to be common for this repo.