### PR TITLE
Subtitle Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The following options are available:
 ```
 usage: slowmovie.py [-h] [-f FILE] [-R] [-r] [-D DIRECTORY] [-d DELAY]
                     [-i INCREMENT] [-s START] [-c CONTRAST] [-l]
+                    [-o {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [-S | -t]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -67,7 +68,7 @@ optional arguments:
                         directory order
   -r, --random-frames   choose a random frame every refresh
   -D DIRECTORY, --directory DIRECTORY
-                        videos directory containing available videos to play
+                        directory containing available videos to play
                         (default: Videos)
   -d DELAY, --delay DELAY
                         delay in seconds between screen updates (default: 120)
@@ -80,14 +81,16 @@ optional arguments:
   -l, --loop            loop a single video; otherwise play through the files
                         in the videos directory
   -o {DEBUG,INFO,WARNING,ERROR,CRITICAL}, --loglevel {DEBUG,INFO,WARNING,ERROR,CRITICAL}
-                         minimum importance-level of messages displayed and
-                         saved to the logfile (default: INFO)
+                        minimum importance-level of messages displayed and
+                        saved to the logfile (default: INFO)
+  -S, --subtitles       Display SRT subtitles
+  -t, --timecode        Display video timecode
 
 Args that start with '--' (eg. -f) can also be set in a config file
 (slowmovie.conf). Config file syntax allows: key=value, flag=true,
-stuff=[a,b,c] (for details, see syntax at https://pypi.org/project/ConfigArgParse).
-If an arg is specified in more than one place, then commandline values override
-config file values, which in turn override defaults.
+stuff=[a,b,c] (for details, see syntax at https://goo.gl/R74nmi). If an arg is
+specified in more than one place, then commandline values override config file
+values which override defaults.
 ```
 
 ### Running as a service

--- a/slowmovie.py
+++ b/slowmovie.py
@@ -118,17 +118,7 @@ def video_info(file):
         # Calculate frametime (ms each frame is displayed)
         frameTime = 1000 / fps
 
-        subtitle_file = None
-
-        # Check for a matching subtitle file
-        if args.subtitle_file:
-            name, _ = os.path.splitext(file)
-            for i in glob.glob(name + ".*"):
-                _, ext = os.path.splitext(i)
-                if ext.lower() in subtitle_fileTypes:
-                    subtitle_file = i
-                    logger.debug(f"Found subtitle file '{i}'")
-                    break
+        subtitle_file = find_subtitles(file, probeInfo["streams"])
 
         info = {
             "frame_count": frameCount,
@@ -198,6 +188,18 @@ def estimate_runtime(delay, increment, frames, output="guess"):
         raise ValueError
 
 
+# Check for a matching subtitle file
+def find_subtitles(file):
+    if args.subtitles:
+        name, _ = os.path.splitext(file)
+        for i in glob.glob(name + ".*"):
+            _, ext = os.path.splitext(i)
+            if ext.lower() in subtitle_fileTypes:
+                logger.debug(f"Found subtitle file '{i}'")
+                return i
+    return None
+
+
 parser = configargparse.ArgumentParser(default_config_files=["slowmovie.conf"])
 parser.add_argument("-f", "--file", type=check_vid, help="video file to start playing; otherwise play the first file in the videos directory")
 parser.add_argument("-R", "--random-file", action="store_true", help="play files in a random order; otherwise play them in directory order")
@@ -209,7 +211,7 @@ parser.add_argument("-s", "--start", type=int, help="start playing at a specific
 parser.add_argument("-c", "--contrast", default=1.0, type=float, help="adjust image contrast (default: %(default)s)")
 parser.add_argument("-l", "--loop", action="store_true", help="loop a single video; otherwise play through the files in the videos directory")
 parser.add_argument("-o", "--loglevel", default="INFO", type=str.upper, choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"], help="minimum importance-level of messages displayed and saved to the logfile (default: %(default)s)")
-parser.add_argument("-S", "--subtitles", action="store_true", help="Display SRT subtitles")
+parser.add_argument("-S", "--subtitles", action="store_true", help="Display subtitles")
 args = parser.parse_args()
 
 # Move to the directory where this code is

--- a/slowmovie.py
+++ b/slowmovie.py
@@ -213,9 +213,9 @@ parser.add_argument("-s", "--start", type=int, help="start playing at a specific
 parser.add_argument("-c", "--contrast", default=1.0, type=float, help="adjust image contrast (default: %(default)s)")
 parser.add_argument("-l", "--loop", action="store_true", help="loop a single video; otherwise play through the files in the videos directory")
 parser.add_argument("-o", "--loglevel", default="INFO", type=str.upper, choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"], help="minimum importance-level of messages displayed and saved to the logfile (default: %(default)s)")
-group = parser.add_mutually_exclusive_group()
-group.add_argument("-S", "--subtitles", action="store_true", help="Display SRT subtitles")
-group.add_argument("-t", "--timecode", action="store_true", help="Display video timecode")
+textOverlayGroup = parser.add_mutually_exclusive_group()
+textOverlayGroup.add_argument("-S", "--subtitles", action="store_true", help="Display SRT subtitles")
+textOverlayGroup.add_argument("-t", "--timecode", action="store_true", help="Display video timecode")
 args = parser.parse_args()
 
 # Move to the directory where this code is

--- a/slowmovie.py
+++ b/slowmovie.py
@@ -214,8 +214,8 @@ parser.add_argument("-c", "--contrast", default=1.0, type=float, help="adjust im
 parser.add_argument("-l", "--loop", action="store_true", help="loop a single video; otherwise play through the files in the videos directory")
 parser.add_argument("-o", "--loglevel", default="INFO", type=str.upper, choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"], help="minimum importance-level of messages displayed and saved to the logfile (default: %(default)s)")
 textOverlayGroup = parser.add_mutually_exclusive_group()
-textOverlayGroup.add_argument("-S", "--subtitles", action="store_true", help="Display SRT subtitles")
-textOverlayGroup.add_argument("-t", "--timecode", action="store_true", help="Display video timecode")
+textOverlayGroup.add_argument("-S", "--subtitles", action="store_true", help="display SRT subtitles")
+textOverlayGroup.add_argument("-t", "--timecode", action="store_true", help="display video timecode")
 args = parser.parse_args()
 
 # Move to the directory where this code is

--- a/slowmovie.py
+++ b/slowmovie.py
@@ -118,7 +118,7 @@ def video_info(file):
         # Calculate frametime (ms each frame is displayed)
         frameTime = 1000 / fps
 
-        subtitle_file = find_subtitles(file, probeInfo["streams"])
+        subtitle_file = find_subtitles(file)
 
         info = {
             "frame_count": frameCount,

--- a/slowmovie.py
+++ b/slowmovie.py
@@ -74,9 +74,9 @@ ffmpeg.Stream.subtitle_filter = subtitle_filter
 # Used by configargparse to check that a file exists and is a compatible video
 def check_vid(value):
     if not os.path.isfile(value):
-        raise configargparse.ArgumentTypeError(f"File '{file}' does not exist")
+        raise configargparse.ArgumentTypeError(f"File '{value}' does not exist")
     if not supported_filetype(value):
-        raise configargparse.ArgumentTypeError(f"File '{file}' should be a file with one of the following supported extensions: {', '.join(fileTypes)}")
+        raise configargparse.ArgumentTypeError(f"File '{value}' should be a file with one of the following supported extensions: {', '.join(fileTypes)}")
     return value
 
 


### PR DESCRIPTION
![out](https://user-images.githubusercontent.com/4073789/115298620-ecdc1500-a11a-11eb-931e-0240dcd5a7f6.png)

I've been sitting on this one for a while because I didn't know if It'd be worth adding.

This adds a `--subtitles` argument that, when enabled, Looks for subtitle files matching the video's filename. Supported filetypes are SRT, SSA, and ASS. Any type supported by ffmpeg should work, but those seem to be the most common.

Embedded subtitle tracks *would* work, but it seems to take a lot longer to extract frames, so I've left that out.

Any thoughts?