### PR TITLE
Add AVI File Type

### DIFF
--- a/slowmovie.py
+++ b/slowmovie.py
@@ -25,7 +25,7 @@ from omni_epd import displayfactory, EPDNotFoundError
 
 
 # Compatible video file-extensions
-fileTypes = [".mp4", ".m4v", ".mkv", ".mov"]
+fileTypes = [".avi", ".mp4", ".m4v", ".mkv", ".mov"]
 subtitle_fileTypes = [".srt", ".ssa", ".ass"]
 
 


### PR DESCRIPTION
I wanted to play some old Futurama episodes that happened to be in an AVI format and didn't feel like converting them. Looks like the existing code works with that format as long as it's listed as an allowed file type. 

```
python3 slowmovie.py -f "/home/pi/Videos/Futurama - The Luck of the Fryrish.S03.E10.avi" -s 200 -i 30
Update interval: 120
Frame increment: 30
Starting at frame 200
Playing 'Futurama - The Luck of the Fryrish.S03.E10.avi'
Video info: 33316 frames, 25.000fps, duration: 00:22:12
This video will take 1.53 day(s) to play.
```