### PR TITLE
fix divide by 0

### DIFF
--- a/slowmovie.py
+++ b/slowmovie.py
@@ -90,7 +90,11 @@ def video_info(file):
 
         # Calculate framerate
         avg_fps = stream["avg_frame_rate"]
-        fps = float(Fraction(avg_fps))
+        # If the returned frame rate fails to convert, use 24
+        try: 
+            fps = float(Fraction(avg_fps))
+        except:
+            fps = 24
 
         # Calculate duration
         duration = float(probeInfo["format"]["duration"])


### PR DESCRIPTION
ffmpeg.probe can return a value of 0/0 for avg_frame_rate. That causes a subsequent conversion function to fail.

This simple fix is to try the conversion and use a default fps if it fails. 