### PR TITLE
Log argparse errors

### DIFF
--- a/slowmovie.py
+++ b/slowmovie.py
@@ -201,7 +201,25 @@ def find_subtitles(file):
     return None
 
 
-parser = configargparse.ArgumentParser(default_config_files=["slowmovie.conf"])
+class argparse_logger(configargparse.ArgumentParser):
+    def error(self, message):
+        logger.error(message)
+        sys.exit()
+
+
+# Set up logging
+logger = logging.getLogger(__name__)
+logger.propagate = False
+
+fileHandler = logging.FileHandler("slowmovie.log")
+fileHandler.setFormatter(logging.Formatter("[%(asctime)s] %(levelname)-8s: %(message)s"))
+logger.addHandler(fileHandler)
+
+consoleHandler = logging.StreamHandler(sys.stdout)
+consoleHandler.setFormatter(logging.Formatter("%(message)s"))
+logger.addHandler(consoleHandler)
+
+parser = argparse_logger(default_config_files=["slowmovie.conf"])
 parser.add_argument("-f", "--file", type=check_vid, help="video file to start playing; otherwise play the first file in the videos directory")
 parser.add_argument("-R", "--random-file", action="store_true", help="play files in a random order; otherwise play them in directory order")
 parser.add_argument("-r", "--random-frames", action="store_true", help="choose a random frame every refresh")
@@ -221,18 +239,8 @@ args = parser.parse_args()
 # Move to the directory where this code is
 os.chdir(os.path.dirname(os.path.realpath(__file__)))
 
-# Set up logging
-logger = logging.getLogger(__name__)
+# Set log level
 logger.setLevel(getattr(logging, args.loglevel))
-logger.propagate = False
-
-fileHandler = logging.FileHandler("slowmovie.log")
-fileHandler.setFormatter(logging.Formatter("[%(asctime)s] %(levelname)-8s: %(message)s"))
-logger.addHandler(fileHandler)
-
-consoleHandler = logging.StreamHandler(sys.stdout)
-consoleHandler.setFormatter(logging.Formatter("%(message)s"))
-logger.addHandler(consoleHandler)
 
 # Set up e-Paper display - do this first since we can't do much if it fails
 try:

--- a/slowmovie.py
+++ b/slowmovie.py
@@ -204,7 +204,7 @@ def find_subtitles(file):
 class argparse_logger(configargparse.ArgumentParser):
     def error(self, message):
         logger.error(message)
-        sys.exit()
+        sys.exit(1)
 
 
 # Set up logging
@@ -253,7 +253,7 @@ except EPDNotFoundError:
     logger.error("\n".join(map(str, validEpds)))
 
     # can't get past this
-    sys.exit()
+    sys.exit(1)
 
 # set width and height
 width = epd.width
@@ -316,7 +316,7 @@ if not currentVideo:
 # ...if none of those worked, exit.
 if not currentVideo:
     logger.critical("No videos found")
-    sys.exit()
+    sys.exit(1)
 
 logger.debug(f"...picked '{currentVideo}'!")
 

--- a/slowmovie.py
+++ b/slowmovie.py
@@ -201,7 +201,7 @@ def find_subtitles(file):
     return None
 
 
-class argparse_logger(configargparse.ArgumentParser):
+class ArgparseLogger(configargparse.ArgumentParser):
     def error(self, message):
         logger.error(message)
         sys.exit(1)
@@ -219,7 +219,7 @@ consoleHandler = logging.StreamHandler(sys.stdout)
 consoleHandler.setFormatter(logging.Formatter("%(message)s"))
 logger.addHandler(consoleHandler)
 
-parser = argparse_logger(default_config_files=["slowmovie.conf"])
+parser = ArgparseLogger(default_config_files=["slowmovie.conf"])
 parser.add_argument("-f", "--file", type=check_vid, help="video file to start playing; otherwise play the first file in the videos directory")
 parser.add_argument("-R", "--random-file", action="store_true", help="play files in a random order; otherwise play them in directory order")
 parser.add_argument("-r", "--random-frames", action="store_true", help="choose a random frame every refresh")


### PR DESCRIPTION
As suggested by @jschrempp, this enables logging for argparse errors.
```console
pi@pizero:~/SlowMovie $ ./slowmovie.py -f null.mp4
argument -f/--file: File 'null.mp4' does not exist
```
```
[2021-05-29 14:45:03,231] ERROR   : argument -f/--file: File 'null.mp4' does not exist
```
