### PR TITLE
Python Libs Update

### DIFF
--- a/Install/install.sh
+++ b/Install/install.sh
@@ -23,7 +23,7 @@ function install_python_packages(){
 
 
   sudo pip3 install setuptools -U
-  sudo pip3 install -r $LOCAL_DIR/Install/requirements.txt
+  sudo pip3 install -r $LOCAL_DIR/Install/requirements.txt -U
 }
 
 function setup_hardware(){

--- a/Install/requirements.txt
+++ b/Install/requirements.txt
@@ -1,4 +1,5 @@
 ffmpeg-python==0.2.0
 Pillow==8.2.0
 ConfigArgParse==1.4.1
+git+https://github.com/waveshare/e-Paper.git#egg=waveshare-epd&subdirectory=RaspberryPi_JetsonNano/python
 git+https://github.com/robweber/omni-epd.git@v0.2.3#egg=omni-epd

--- a/Install/requirements.txt
+++ b/Install/requirements.txt
@@ -1,5 +1,4 @@
 ffmpeg-python
 pillow
 ConfigArgParse
-git+https://github.com/waveshare/e-Paper.git#egg=waveshare-epd&subdirectory=RaspberryPi_JetsonNano/python
 git+https://github.com/robweber/omni-epd.git#egg=omni-epd

--- a/Install/requirements.txt
+++ b/Install/requirements.txt
@@ -1,4 +1,4 @@
-ffmpeg-python
-pillow
-ConfigArgParse
-git+https://github.com/robweber/omni-epd.git#egg=omni-epd
+ffmpeg-python==0.2.0
+Pillow==8.2.0
+ConfigArgParse==1.4.1
+git+https://github.com/robweber/omni-epd.git@v0.2.3#egg=omni-epd

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ For first-time automated installation, choose 1: Install/Upgrade SlowMovie. When
 
 ### Manual installation
 
+_Note that the `omni-epd` package installs Waveshare and Inky EPD driver libraries._
 On the Raspberry Pi:
 
 0. Make sure SPI is enabled
@@ -50,19 +51,17 @@ On the Raspberry Pi:
    * Make sure git is installed: `sudo apt install git`
    * Make sure pip is installed: `sudo apt install python3-pip`
    * Make sure setuptools is updated: `sudo pip3 install setuptools -U`
-2. Install Waveshare e-paper drivers
-   * `sudo pip3 install git+https://github.com/waveshare/e-Paper.git#egg=waveshare-epd&subdirectory=RaspberryPi_JetsonNano/python`
-3. Clone this repo
+2. Clone this repo
    * `git clone https://github.com/TomWhitwell/SlowMovie`
    * Navigate to the new SlowMovie directory: `cd SlowMovie/`
    * Copy the default configuration file: `cp Install/slowmovie-default.conf slowmovie.conf`
-4. Make sure dependencies are installed
+3. Make sure dependencies are installed
    * `sudo apt install ffmpeg`
    * `sudo pip3 install ffmpeg-python`
    * `sudo pip3 install pillow`
    * `sudo pip3 install ConfigArgParse`
    * `sudo pip3 install git+https://github.com/robweber/omni-epd.git#egg=omni-epd`
-5. Test it out
+4. Test it out
    * Run `python3 slowmovie.py`. If everything's installed properly, this should start playing `test.mp4` (a clip from _Psycho_) from the `Videos` directory.
 
 ## Usage
@@ -116,7 +115,7 @@ values which override defaults.
 
 The guide for this program uses the [7.5-inch Waveshare display](https://www.waveshare.com/product/displays/e-paper/epaper-1/7.5inch-e-paper-hat.htm), this is the device driver loaded by default in the `slowmovie.conf` file. It is possible to specify other devices by editing the file or using the command line `-e` option. You can view a list of compatible e-ink devices on the [Omni-EPD repo](https://github.com/robweber/omni-epd/blob/main/README.md#displays-implemented).
 
-Customizing other options of the display is also possible by creating a file called `omni-epd.ini` in the SlowMovie directory. Common options for this file are listed below with a full explanation of all options available. 
+Customizing other options of the display is also possible by creating a file called `omni-epd.ini` in the SlowMovie directory. Common options for this file are listed below with a full explanation of all options available.
 
 ```
 [Display]

--- a/README.md
+++ b/README.md
@@ -50,17 +50,19 @@ On the Raspberry Pi:
    * Update package sources: `sudo apt update`
    * Make sure git is installed: `sudo apt install git`
    * Make sure pip is installed: `sudo apt install python3-pip`
-2. Clone this repo
+2. Install Waveshare e-paper drivers
+   * `pip3 install git+https://github.com/waveshare/e-Paper.git#egg=waveshare-epd&subdirectory=RaspberryPi_JetsonNano/python`
+3. Clone this repo
    * `git clone https://github.com/TomWhitwell/SlowMovie`
    * Navigate to the new SlowMovie directory: `cd SlowMovie/`
    * Copy the default configuration file: `cp Install/slowmovie-default.conf slowmovie.conf`
-3. Make sure dependencies are installed
+4. Make sure dependencies are installed
    * `sudo apt install ffmpeg`
    * `pip3 install ffmpeg-python`
    * `pip3 install pillow`
    * `pip3 install ConfigArgParse`
    * `pip3 install git+https://github.com/robweber/omni-epd.git#egg=omni-epd`
-4. Test it out
+5. Test it out
    * Run `python3 slowmovie.py`. If everything's installed properly, this should start playing `test.mp4` (a clip from _Psycho_) from the `Videos` directory.
 
 ## Usage


### PR DESCRIPTION
When running the `install.sh` file Python lib dependencies are not updated. It appears as though when installing from a git URL using pip it will not honor version updates in a setup.py or setup.cfg file. 

The fix for this is to use the `-U` flag to force updates of all dependencies to the latest version. This works great but one question before merging I have is if we want to start specifying specific versions within the `requirements.txt` file? Our requirements for these libraries are pretty minimal so it's unlikely updates will break things; however by specifying known working versions we are covering our bases as well. For Git URLs you can specify a tagged revision so for libs like `omni-epd` we can add `@v0.2.3` as part of the URL string.

Of course the downside to this is that we'll need a lot more hand-holding to the `requiements.txt` file as versions of the libraries change. Any thoughts on this? 
