### PR TITLE
Run pip without sudo

### DIFF
--- a/Install/install.sh
+++ b/Install/install.sh
@@ -15,15 +15,11 @@ SERVICE_FILE=slowmovie.service
 
 function install_linux_packages(){
   sudo apt-get update
-
   sudo apt-get install -y ffmpeg git python3-pip
 }
 
 function install_python_packages(){
-
-
-  sudo pip3 install setuptools -U
-  sudo pip3 install -r $LOCAL_DIR/Install/requirements.txt
+  pip3 install -r $LOCAL_DIR/Install/requirements.txt
 }
 
 function setup_hardware(){

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ On the Raspberry Pi:
    * `pip3 install ffmpeg-python`
    * `pip3 install pillow`
    * `pip3 install ConfigArgParse`
-   * `pip3 install git+https://github.com/robweber/omni-epd.git#egg=omni-epd
+   * `pip3 install git+https://github.com/robweber/omni-epd.git#egg=omni-epd`
 5. Test it out
    * Run `python3 slowmovie.py`. If everything's installed properly, this should start playing `test.mp4` (a clip from _Psycho_) from the `Videos` directory.
 

--- a/README.md
+++ b/README.md
@@ -49,19 +49,18 @@ On the Raspberry Pi:
    * Update package sources: `sudo apt update`
    * Make sure git is installed: `sudo apt install git`
    * Make sure pip is installed: `sudo apt install python3-pip`
-   * Make sure setuptools is updated: `sudo pip3 install setuptools -U`
 2. Install Waveshare e-paper drivers
-   * `sudo pip3 install git+https://github.com/waveshare/e-Paper.git#egg=waveshare-epd&subdirectory=RaspberryPi_JetsonNano/python`
+   * `pip3 install git+https://github.com/waveshare/e-Paper.git#egg=waveshare-epd&subdirectory=RaspberryPi_JetsonNano/python`
 3. Clone this repo
    * `git clone https://github.com/TomWhitwell/SlowMovie`
    * Navigate to the new SlowMovie directory: `cd SlowMovie/`
    * Copy the default configuration file: `cp Install/slowmovie-default.conf slowmovie.conf`
 4. Make sure dependencies are installed
    * `sudo apt install ffmpeg`
-   * `sudo pip3 install ffmpeg-python`
-   * `sudo pip3 install pillow`
-   * `sudo pip3 install ConfigArgParse`
-   * `sudo pip3 install git+https://github.com/robweber/omni-epd.git#egg=omni-epd`
+   * `pip3 install ffmpeg-python`
+   * `pip3 install pillow`
+   * `pip3 install ConfigArgParse`
+   * `pip3 install git+https://github.com/robweber/omni-epd.git#egg=omni-epd
 5. Test it out
    * Run `python3 slowmovie.py`. If everything's installed properly, this should start playing `test.mp4` (a clip from _Psycho_) from the `Videos` directory.
 


### PR DESCRIPTION
I just tried this on a freshly-imaged card, works fine this way. Pip isn't really supposed to be run as root anyway. Everything goes in `~/.local/lib` instead. It does produce warnings like this:
```
The script omni-epd-test is installed in '/home/pi/.local/bin' which is not on PATH.
Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
```
...but this is already handled in `.profile`.
```shell
# set PATH so it includes user's private bin if it exists
if [ -d "$HOME/.local/bin" ] ; then
    PATH="$HOME/.local/bin:$PATH"
fi
```

I've also removed the "update setuptools" step. That doesn't seem to be necessary anymore.