### PR TITLE
Global logging

### DIFF
--- a/slowmovie.py
+++ b/slowmovie.py
@@ -240,8 +240,9 @@ textOverlayGroup.add_argument("-S", "--subtitles", action="store_true", help="di
 textOverlayGroup.add_argument("-t", "--timecode", action="store_true", help="display video timecode")
 args = parser.parse_args()
 
-# Set log level
-logger.setLevel(getattr(logging, args.loglevel))
+# Set log level globally for all logs
+#logger.setLevel(getattr(logging, args.loglevel))
+logging.basicConfig(level=getattr(logging, args.loglevel))
 
 # Set up e-Paper display - do this first since we can't do much if it fails
 try:

--- a/slowmovie.py
+++ b/slowmovie.py
@@ -212,11 +212,10 @@ class ArgparseLogger(configargparse.ArgumentParser):
 
 
 # Set up logging
-logger = logging.getLogger(__name__)
-logger.propagate = False
+logger = logging.getLogger()
 
 fileHandler = logging.FileHandler("slowmovie.log")
-fileHandler.setFormatter(logging.Formatter("[%(asctime)s] %(levelname)-8s: %(message)s"))
+fileHandler.setFormatter(logging.Formatter("[%(asctime)s] %(levelname)-8s: %(module)s : %(message)s"))
 logger.addHandler(fileHandler)
 
 consoleHandler = logging.StreamHandler(sys.stdout)
@@ -240,8 +239,8 @@ textOverlayGroup.add_argument("-S", "--subtitles", action="store_true", help="di
 textOverlayGroup.add_argument("-t", "--timecode", action="store_true", help="display video timecode")
 args = parser.parse_args()
 
-# Set log level globally for all logs
-logging.basicConfig(level=getattr(logging, args.loglevel))
+# Set log level
+logger.setLevel(getattr(logging, args.loglevel))
 
 # Set up e-Paper display - do this first since we can't do much if it fails
 try:

--- a/slowmovie.py
+++ b/slowmovie.py
@@ -220,7 +220,7 @@ fileHandler.setFormatter(logging.Formatter("[%(asctime)s] %(levelname)-8s: %(mes
 logger.addHandler(fileHandler)
 
 consoleHandler = logging.StreamHandler(sys.stdout)
-consoleHandler.setFormatter(logging.Formatter("%(message)s"))
+consoleHandler.setFormatter(logging.Formatter("%(levelname)s:%(module)s:%(message)s"))
 logger.addHandler(consoleHandler)
 
 parser = ArgparseLogger(default_config_files=["slowmovie.conf"])
@@ -241,7 +241,6 @@ textOverlayGroup.add_argument("-t", "--timecode", action="store_true", help="dis
 args = parser.parse_args()
 
 # Set log level globally for all logs
-#logger.setLevel(getattr(logging, args.loglevel))
 logging.basicConfig(level=getattr(logging, args.loglevel))
 
 # Set up e-Paper display - do this first since we can't do much if it fails


### PR DESCRIPTION
This sets the log level value for the Python global logger as well. This allows the console output to show messages from other modules (like Waveshare) that use logging. This won't affect the regular log file since that handler is for the SlowMovie logger only. 

Without this collecting logs from the other modules is basically impossible without modifying the code directly. 