### PR TITLE
omni-epd 0.2.4

### DIFF
--- a/Install/requirements.txt
+++ b/Install/requirements.txt
@@ -2,4 +2,4 @@ ffmpeg-python==0.2.0
 Pillow==8.2.0
 ConfigArgParse==1.4.1
 git+https://github.com/waveshare/e-Paper.git#egg=waveshare-epd&subdirectory=RaspberryPi_JetsonNano/python
-git+https://github.com/robweber/omni-epd.git@v0.2.3#egg=omni-epd
+git+https://github.com/robweber/omni-epd.git@v0.2.4#egg=omni-epd


### PR DESCRIPTION
Updates omni-epd to version 0.2.4. This fixes issues with the Waveshare 3.7in devices. This device is tested and working properly now. 