### PR TITLE
omni-epd v0.2.5

### DIFF
--- a/Install/requirements.txt
+++ b/Install/requirements.txt
@@ -2,4 +2,4 @@ ffmpeg-python==0.2.0
 Pillow==8.2.0
 ConfigArgParse==1.4.1
 git+https://github.com/waveshare/e-Paper.git#egg=waveshare-epd&subdirectory=RaspberryPi_JetsonNano/python
-git+https://github.com/robweber/omni-epd.git@v0.2.4#egg=omni-epd
+git+https://github.com/robweber/omni-epd.git@v0.2.5#egg=omni-epd


### PR DESCRIPTION
Update to latest version of omni-epd. This includes fixes and tested support for two additional EPD types. 

* waveshare_epd.epd2in9
* waveshare_epd.epd5in83c