### PR TITLE
Update waveshare driver URL to match install.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ On the Raspberry Pi:
    * Make sure git is installed: `sudo apt install git`
    * Make sure pip is installed: `sudo apt install python3-pip`
 2. Install Waveshare e-paper drivers
-   * `pip3 install git+https://github.com/waveshare/e-Paper.git#egg=waveshare-epd&subdirectory=RaspberryPi_JetsonNano/python`
+   * `pip3 install git+https://github.com/waveshare/e-Paper.git#subdirectory=RaspberryPi_JetsonNano/python&egg=waveshare-epd`
 3. Clone this repo
    * `git clone https://github.com/TomWhitwell/SlowMovie`
    * Navigate to the new SlowMovie directory: `cd SlowMovie/`


### PR DESCRIPTION
This change updates the README waveshare-epd driver installation in the manual instructions to match the install.txt.

Relates to https://github.com/TomWhitwell/SlowMovie/pull/104