### PR TITLE
Help Menu Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,36 +74,46 @@ Put videos in the `Videos` directory. Run `python3 slowmovie.py` to start the pr
 The following options are available:
 
 ```
-usage: slowmovie.py [-h] [-f FILE] [-R] [-r] [-D DIRECTORY] [-d DELAY]
-                    [-i INCREMENT] [-s START] [-c CONTRAST] [-l]
-                    [-o {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [-S | -t]
+usage: slowmovie.py [-h] [-f FILE] [-D DIRECTORY] [-l] [-R]
+                    [-o {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [-r] [-d DELAY]
+                    [-i INCREMENT] [-s START] [-S | -t] [-e EPD] [-c CONTRAST]
+                    [-C]
 
 optional arguments:
   -h, --help            show this help message and exit
   -f FILE, --file FILE  video file to start playing; otherwise play the first
                         file in the videos directory
-  -R, --random-file     play files in a random order; otherwise play them in
-                        directory order
-  -r, --random-frames   choose a random frame every refresh
   -D DIRECTORY, --directory DIRECTORY
                         directory containing available videos to play
                         (default: Videos)
+  -l, --loop            loop a single video; otherwise play through the files
+                        in the videos directory
+  -R, --random-file     play files in a random order; otherwise play them in
+                        directory order
+  -o {DEBUG,INFO,WARNING,ERROR,CRITICAL}, --loglevel {DEBUG,INFO,WARNING,ERROR,CRITICAL}
+                        minimum importance-level of messages displayed and
+                        saved to the logfile (default: INFO)
+
+Frame Update Args:
+  arguments that control frame updates and display
+
+  -r, --random-frames   choose a random frame every refresh
   -d DELAY, --delay DELAY
                         delay in seconds between screen updates (default: 120)
   -i INCREMENT, --increment INCREMENT
                         advance INCREMENT frames each refresh (default: 4)
   -s START, --start START
                         start playing at a specific frame
+  -S, --subtitles       display SRT subtitles
+  -t, --timecode        display video timecode
+
+EPD Args:
+  arguments to select and modify the e-Ink display
+
+  -e EPD, --epd EPD     the name of the display device driver to use
   -c CONTRAST, --contrast CONTRAST
                         adjust image contrast (default: 1.0)
-  -l, --loop            loop a single video; otherwise play through the files
-                        in the videos directory
-  -e, --epd             the name of the display device driver to use (default: waveshare_epd.epd7in5_V2)
-  -o {DEBUG,INFO,WARNING,ERROR,CRITICAL}, --loglevel {DEBUG,INFO,WARNING,ERROR,CRITICAL}
-                        minimum importance-level of messages displayed and
-                        saved to the logfile (default: INFO)
-  -S, --subtitles       Display SRT subtitles
-  -t, --timecode        Display video timecode
+  -C, --clear           clear display on exit
 
 Args that start with '--' (eg. -f) can also be set in a config file
 (slowmovie.conf). Config file syntax allows: key=value, flag=true,

--- a/slowmovie.py
+++ b/slowmovie.py
@@ -225,22 +225,30 @@ consoleHandler = logging.StreamHandler(sys.stdout)
 consoleHandler.setFormatter(logging.Formatter("%(levelname)s:%(module)s:%(message)s"))
 logger.addHandler(consoleHandler)
 
+# parse config or CLI arguments
 parser = ArgparseLogger(default_config_files=["slowmovie.conf"])
 parser.add_argument("-f", "--file", type=check_vid, help="video file to start playing; otherwise play the first file in the videos directory")
-parser.add_argument("-R", "--random-file", action="store_true", help="play files in a random order; otherwise play them in directory order")
-parser.add_argument("-r", "--random-frames", action="store_true", help="choose a random frame every refresh")
 parser.add_argument("-D", "--directory", type=check_dir, help="directory containing available videos to play (default: Videos)")
-parser.add_argument("-d", "--delay", default=120, type=int, help="delay in seconds between screen updates (default: %(default)s)")
-parser.add_argument("-i", "--increment", default=4, type=int, help="advance INCREMENT frames each refresh (default: %(default)s)")
-parser.add_argument("-s", "--start", type=int, help="start playing at a specific frame")
-parser.add_argument("-c", "--contrast", default=1.0, type=float, help="adjust image contrast (default: %(default)s)")
 parser.add_argument("-l", "--loop", action="store_true", help="loop a single video; otherwise play through the files in the videos directory")
-parser.add_argument("-e", "--epd", help="the name of the display device driver to use")
+parser.add_argument("-R", "--random-file", action="store_true", help="play files in a random order; otherwise play them in directory order")
 parser.add_argument("-o", "--loglevel", default="INFO", type=str.upper, choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"], help="minimum importance-level of messages displayed and saved to the logfile (default: %(default)s)")
-parser.add_argument("-C", "--clear", action="store_true", help="clear display on exit")
-textOverlayGroup = parser.add_mutually_exclusive_group()
+
+# frame update controls
+argsControl = parser.add_argument_group("Frame Update Controls", "arguments that control frame updates")
+argsControl.add_argument("-r", "--random-frames", action="store_true", help="choose a random frame every refresh")
+argsControl.add_argument("-d", "--delay", default=120, type=int, help="delay in seconds between screen updates (default: %(default)s)")
+argsControl.add_argument("-i", "--increment", default=4, type=int, help="advance INCREMENT frames each refresh (default: %(default)s)")
+argsControl.add_argument("-s", "--start", type=int, help="start playing at a specific frame")
+textOverlayGroup = argsControl.add_mutually_exclusive_group()
 textOverlayGroup.add_argument("-S", "--subtitles", action="store_true", help="display SRT subtitles")
 textOverlayGroup.add_argument("-t", "--timecode", action="store_true", help="display video timecode")
+
+# epd controls
+argsEpd = parser.add_argument_group("EPD Args", "arguments to select and modify the e-Ink display")
+argsEpd.add_argument("-e", "--epd", help="the name of the display device driver to use")
+argsEpd.add_argument("-c", "--contrast", default=1.0, type=float, help="adjust image contrast (default: %(default)s)")
+argsEpd.add_argument("-C", "--clear", action="store_true", help="clear display on exit")
+
 args = parser.parse_args()
 
 # Set log level

--- a/slowmovie.py
+++ b/slowmovie.py
@@ -234,7 +234,7 @@ parser.add_argument("-R", "--random-file", action="store_true", help="play files
 parser.add_argument("-o", "--loglevel", default="INFO", type=str.upper, choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"], help="minimum importance-level of messages displayed and saved to the logfile (default: %(default)s)")
 
 # frame update controls
-argsControl = parser.add_argument_group("Frame Update Controls", "arguments that control frame updates")
+argsControl = parser.add_argument_group("Frame Update Args", "arguments that control frame updates and display")
 argsControl.add_argument("-r", "--random-frames", action="store_true", help="choose a random frame every refresh")
 argsControl.add_argument("-d", "--delay", default=120, type=int, help="delay in seconds between screen updates (default: %(default)s)")
 argsControl.add_argument("-i", "--increment", default=4, type=int, help="advance INCREMENT frames each refresh (default: %(default)s)")


### PR DESCRIPTION
There are currently a lot of arguments that can be set in either the config file or passed via the command line. This doesn't change any of them in any way, but it does re-organize the help menu when using `-h`. Using argument groups, options are put into sections that help the user sort through which they may need in a better fashion. Instead of everything being listed in one lump it's now easier to tell which are for specifying the file to load, settings for frame updates, and EPD control. 

Reorganized `-h` output now looks like this: 
```
usage: slowmovie.py [-h] [-f FILE] [-D DIRECTORY] [-l] [-R]
                    [-o {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [-r] [-d DELAY]
                    [-i INCREMENT] [-s START] [-S | -t] [-e EPD] [-c CONTRAST]
                    [-C]

optional arguments:
  -h, --help            show this help message and exit
  -f FILE, --file FILE  video file to start playing; otherwise play the first
                        file in the videos directory
  -D DIRECTORY, --directory DIRECTORY
                        directory containing available videos to play
                        (default: Videos)
  -l, --loop            loop a single video; otherwise play through the files
                        in the videos directory
  -R, --random-file     play files in a random order; otherwise play them in
                        directory order
  -o {DEBUG,INFO,WARNING,ERROR,CRITICAL}, --loglevel {DEBUG,INFO,WARNING,ERROR,CRITICAL}
                        minimum importance-level of messages displayed and
                        saved to the logfile (default: INFO)

Frame Update Args:
  arguments that control frame updates and display

  -r, --random-frames   choose a random frame every refresh
  -d DELAY, --delay DELAY
                        delay in seconds between screen updates (default: 120)
  -i INCREMENT, --increment INCREMENT
                        advance INCREMENT frames each refresh (default: 4)
  -s START, --start START
                        start playing at a specific frame
  -S, --subtitles       display SRT subtitles
  -t, --timecode        display video timecode

EPD Args:
  arguments to select and modify the e-Ink display

  -e EPD, --epd EPD     the name of the display device driver to use
  -c CONTRAST, --contrast CONTRAST
                        adjust image contrast (default: 1.0)
  -C, --clear           clear display on exit

Args that start with '--' (eg. -f) can also be set in a config file
(slowmovie.conf). Config file syntax allows: key=value, flag=true,
stuff=[a,b,c] (for details, see syntax at https://goo.gl/R74nmi). If an arg is
specified in more than one place, then commandline values override config file
values which override defaults.
```