### PR TITLE
Filter out hidden files

### DIFF
--- a/slowmovie.py
+++ b/slowmovie.py
@@ -97,7 +97,7 @@ def check_dir(value):
 
 def supported_filetype(file):
     _, ext = os.path.splitext(file)
-    return ext.lower() in fileTypes
+    return ext.lower() in fileTypes and not file.startswith('.')
 
 
 # Get framerate, frame count, duration, and frame-time of video via FFmpeg probe


### PR DESCRIPTION
This will solve the problem found in #111 where hidden files that weren't actually video files were being included in the file listing. `os.listdir()` returns hidden system files that start with a dot (`.`). This fix will filter them out at the time the file list is being generated. In the issue referenced above files such as `._test.mp4` were being included. I imagine this happens when entire directories are copied from other computers (Mac, Windows) that have generated things like thumbnails that include the full file name. 

I tried a few different ways of doing this, including using the `glob` package; but this seemed the most efficient. glob returned the absolute path to the files instead of just the filename, which would have created a bunch of downstream problems as we're expecting just the filename in other places of the code. I also didn't want to iterate through the list twice since we're doing the video file ext filter anyway. Doing them at the same time seemed the easiest and got rid of the hidden files. 