### PR TITLE
Updated omni-epd 0.2.6

### DIFF
--- a/Install/requirements.txt
+++ b/Install/requirements.txt
@@ -2,4 +2,4 @@ ffmpeg-python==0.2.0
 Pillow==8.2.0
 ConfigArgParse==1.4.1
 git+https://github.com/waveshare/e-Paper.git#subdirectory=RaspberryPi_JetsonNano/python&egg=waveshare-epd
-git+https://github.com/robweber/omni-epd.git@v0.2.5#egg=omni-epd
+git+https://github.com/robweber/omni-epd.git@v0.2.6#egg=omni-epd


### PR DESCRIPTION
This is the most recent omni-epd release. Minor fixes to a few EPD classes. Full changelog link is below: 

https://github.com/robweber/omni-epd/releases/tag/v0.2.6