### PR TITLE
omni-epd to 0.3.0

### DIFF
--- a/Install/requirements.txt
+++ b/Install/requirements.txt
@@ -2,4 +2,4 @@ ffmpeg-python==0.2.0
 Pillow==8.2.0
 ConfigArgParse==1.4.1
 git+https://github.com/waveshare/e-Paper.git#subdirectory=RaspberryPi_JetsonNano/python&egg=waveshare-epd
-git+https://github.com/robweber/omni-epd.git@v0.2.5#egg=omni-epd
+git+https://github.com/robweber/omni-epd.git@v0.3.0#egg=omni-epd


### PR DESCRIPTION
This will bump the omni-epd version to 0.3.0. This version includes support for IT8951 devices as well as the ability to use `inky.auto` to auto detect Inky displays. Numerous other bug fixes as well that can be found in [the Changelog](https://github.com/robweber/omni-epd/blob/main/CHANGELOG.md). 