### PR TITLE
update omni-epd to version 0.3.1

### DIFF
--- a/Install/requirements.txt
+++ b/Install/requirements.txt
@@ -2,4 +2,4 @@ ffmpeg-python==0.2.0
 Pillow==9.0.1
 ConfigArgParse==1.4.1
 git+https://github.com/waveshare/e-Paper.git#subdirectory=RaspberryPi_JetsonNano/python&egg=waveshare-epd
-git+https://github.com/robweber/omni-epd.git@v0.3.0#egg=omni-epd
+git+https://github.com/robweber/omni-epd.git@v0.3.1#egg=omni-epd


### PR DESCRIPTION
This will update omni-epd to the latest version. The full changelog is below but the big change in this revision is enhancements to the [dithering options](https://github.com/robweber/omni-epd/wiki/Image-Dithering-Options). There are more and they work faster. 


## Version 0.3.1

### Added

- `omni_epd.mock` can now set both the width and height values within the `.ini` file. Thanks @missionfloyd

### Fixed

- `omni_epd.mock` device now returns a palette filter when using the color mode. Previously this returned only b/w and resulted in image processing enhancements resulting in a black and white only image, even when color was selected. Hardcoded palette based on web safe colors.

- Waveshare device `epd2in13_V2` should use the alternate clear method which requires a color parameter. Thanks @ThatIsAPseudo for pointing this out

### Changed

- dithering is now done with [didder](https://github.com/makeworld-the-better-one/didder) - this is a massive improvement both in scope and speed to hitherdither. Thanks @missionfloyd

### Removed

- removed `hitherdither` as a dependency