### PR TITLE
Update omni-epd and Pillow versions

### DIFF
--- a/Install/requirements.txt
+++ b/Install/requirements.txt
@@ -1,5 +1,5 @@
 ffmpeg-python==0.2.0
-Pillow==9.0.1
+Pillow>=9.1.0
 ConfigArgParse==1.4.1
 git+https://github.com/waveshare/e-Paper.git#subdirectory=RaspberryPi_JetsonNano/python&egg=waveshare-epd
-git+https://github.com/robweber/omni-epd.git@v0.3.1#egg=omni-epd
+git+https://github.com/robweber/omni-epd.git@v0.3.2#egg=omni-epd


### PR DESCRIPTION
This updates omni-epd to version 0.3.2 and makes the Pillow version equal to, or greater than, version 9.1.0. 

The [big changes](https://github.com/robweber/omni-epd/releases/tag/v0.3.2) with omni-epd are the addition of some new Waveshare devices and a bump in Pillow to 9.1.0 or greater. This translates to why the Pillow bump here as well. The [Pillow release notes](https://pillow.readthedocs.io/en/latest/releasenotes/9.1.0.html#constants) explain that some of the constants in that library have migrated and the old ones removed in a later release. This makes sure everything is on the same minimum version. 