### PR TITLE
Dynamic Install Path

### DIFF
--- a/Install/install.sh
+++ b/Install/install.sh
@@ -12,6 +12,7 @@ RESET="\e[0m"
 # file paths
 SERVICE_DIR=/etc/systemd/system
 SERVICE_FILE=slowmovie.service
+SERVICE_FILE_TEMPLATE=slowmovie.service.template
 
 function install_linux_packages(){
   sudo apt-get update
@@ -88,7 +89,9 @@ function install_slowmovie(){
 
   # check if the service file needs to be updated
   if (service_installed) && ! (cmp -s "slowmovie.service" "/etc/systemd/system/slowmovie.service"); then
-    sudo cp $SERVICE_FILE $SERVICE_DIR
+    # generate the service file from the template and move it
+    envsubst <$SERVICE_FILE_TEMPLATE > $SERVICE_FILE
+    sudo mv $SERVICE_FILE $SERVICE_DIR
     sudo systemctl daemon-reload
 
     echo -e "Updating SlowMovie service file"

--- a/Install/install.sh
+++ b/Install/install.sh
@@ -66,7 +66,7 @@ function install_slowmovie(){
     git pull
 
     # go back to home directory
-    cd /home/pi/
+    cd /home/$USER/
   else
     echo -e "No Install Found - Cloning Repo"
     git clone -b ${GIT_BRANCH} ${GIT_REPO} ${LOCAL_DIR}
@@ -118,7 +118,7 @@ function install_service(){
   fi
 
   # go back to home
-  cd /home/pi
+  cd /home/$USER
 }
 
 function uninstall_service(){
@@ -160,9 +160,9 @@ while getopts ":r:b:si:h" arg; do
 done
 
 # set the local directory
-LOCAL_DIR="/home/pi/$(basename $GIT_REPO)"
+LOCAL_DIR="/home/$USER/$(basename $GIT_REPO)"
 
-cd /home/pi/
+cd /home/$USER/
 
 # check if service is currently running and stop if it is
 RESTART_SERVICE="FALSE"

--- a/Install/install.sh
+++ b/Install/install.sh
@@ -67,7 +67,7 @@ function install_slowmovie(){
     git pull
 
     # go back to home directory
-    cd /home/$USER/
+    cd $HOME
   else
     echo -e "No Install Found - Cloning Repo"
     git clone -b ${GIT_BRANCH} ${GIT_REPO} ${LOCAL_DIR}
@@ -121,7 +121,7 @@ function install_service(){
   fi
 
   # go back to home
-  cd /home/$USER
+  cd $HOME
 }
 
 function uninstall_service(){
@@ -163,9 +163,9 @@ while getopts ":r:b:si:h" arg; do
 done
 
 # set the local directory
-LOCAL_DIR="/home/$USER/$(basename $GIT_REPO)"
+LOCAL_DIR="$HOME/$(basename $GIT_REPO)"
 
-cd /home/$USER/
+cd $HOME
 
 # check if service is currently running and stop if it is
 RESTART_SERVICE="FALSE"

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Now you can use the `systemctl` command to start and stop the program, and enabl
 | `sudo systemctl enable slowmovie`          | Enable the service auto-starting on boot    |
 | `sudo systemctl disable slowmovie`         | Disable the service auto-starting on boot   |
 | `systemctl status slowmovie`               | Display the status of the SlowMovie service |
-| `tail -f /home/$USER/SlowMovie/slowmovie.log` | Show the logs for the SlowMovie service     |
+| `tail -f ~/SlowMovie/slowmovie.log`    | Show the logs for the SlowMovie service     |
 
 So, if you want SlowMovie to start automatically when the device is powered on, run:
 
@@ -182,7 +182,7 @@ So, if you want SlowMovie to start automatically when the device is powered on, 
 sudo systemctl enable slowmovie
 ```
 
-And if something goes wrong, the first step is to check the logs for an error message. The command above will show the last few lines of the log file but you can view the entire file located at `/home/$USER/SlowMovie/slowmovie.log` with any text editor.
+And if something goes wrong, the first step is to check the logs for an error message. The command above will show the last few lines of the log file but you can view the entire file located at `~/SlowMovie/slowmovie.log` with any text editor.
 
 ## Maintainers
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Now you can use the `systemctl` command to start and stop the program, and enabl
 | `sudo systemctl enable slowmovie`          | Enable the service auto-starting on boot    |
 | `sudo systemctl disable slowmovie`         | Disable the service auto-starting on boot   |
 | `systemctl status slowmovie`               | Display the status of the SlowMovie service |
-| `tail -f /home/pi/SlowMovie/slowmovie.log` | Show the logs for the SlowMovie service     |
+| `tail -f /home/$USER/SlowMovie/slowmovie.log` | Show the logs for the SlowMovie service     |
 
 So, if you want SlowMovie to start automatically when the device is powered on, run:
 
@@ -181,7 +181,7 @@ So, if you want SlowMovie to start automatically when the device is powered on, 
 sudo systemctl enable slowmovie
 ```
 
-And if something goes wrong, the first step is to check the logs for an error message. The command above will show the last few lines of the log file but you can view the entire file located at `/home/pi/SlowMovie/slowmovie.log` with any text editor.
+And if something goes wrong, the first step is to check the logs for an error message. The command above will show the last few lines of the log file but you can view the entire file located at `/home/$USER/SlowMovie/slowmovie.log` with any text editor.
 
 ## Maintainers
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ sharpness=1  # adjust image sharpness, 1 = no adjustment
 SlowMovie can run as a service. To set this up you can either use option 2 from the install script ( [see above](https://github.com/TomWhitwell/SlowMovie#automated-installation) ) or from the SlowMovie directory run the following:
 
 ```
-sudo cp slowmovie.service /etc/systemd/system
+envsubst <slowmovie.service.template > slowmovie.service
+sudo mv slowmovie.service /etc/systemd/system
 sudo systemctl daemon-reload
 ```
 

--- a/slowmovie.service.template
+++ b/slowmovie.service.template
@@ -3,8 +3,8 @@ Description=Slow Movie Player Service
 
 [Service]
 User=${USER}
-WorkingDirectory=/home/${USER}/SlowMovie
-ExecStart=/usr/bin/python3 /home/${USER}/SlowMovie/slowmovie.py
+WorkingDirectory=${HOME}/SlowMovie
+ExecStart=/usr/bin/python3 ${HOME}/SlowMovie/slowmovie.py
 StandardOutput=null
 StandardError=journal
 

--- a/slowmovie.service.template
+++ b/slowmovie.service.template
@@ -2,9 +2,9 @@
 Description=Slow Movie Player Service
 
 [Service]
-User=pi
-WorkingDirectory=/home/pi/SlowMovie
-ExecStart=/usr/bin/python3 /home/pi/SlowMovie/slowmovie.py
+User=${USER}
+WorkingDirectory=/home/${USER}/SlowMovie
+ExecStart=/usr/bin/python3 /home/${USER}/SlowMovie/slowmovie.py
 StandardOutput=null
 StandardError=journal
 


### PR DESCRIPTION
With newer versions of the Raspberry Pi OS you can't count on the default `pi` user being the path for the home folder anymore. This PR attempts to modify the install procedure and the install script to insert the current user name in places where a full path is needed. For the `install.sh` script this is pretty simple. I just replaced any hardcoded paths from `/home/pi` to `/home/$USER`. 

The one piece that was a little tricky was the `slowmovie.service` file. This needed to be updated on the fly rather than a static file with hardcoded paths. I utilized the [envsubst](https://manpages.debian.org/unstable/gettext-base/envsubst.1.en.html) shell function to generate the service file from a template and then move that file to the correct location. 

### Limitations

This is a 1:1 replacement for the current install procedure. It doesn't try and account for more dynamic path options like someone having a completely different path for the SlowMovie install other than as a subdirectory in the user's home folder (`/home/$USER/SlowMovie`). That could probably be added based on these modifications but that wasn't the intent here. 