### PR TITLE
Crop out borders

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ The following options are available:
 ```
 usage: slowmovie.py [-h] [-f FILE] [-D DIRECTORY] [-l] [-R]
                     [-o {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [-r] [-d DELAY]
-                    [-i INCREMENT] [-s START] [-S | -t] [-e EPD] [-c CONTRAST]
-                    [-C]
+                    [-i INCREMENT] [-s START] [-F] [-S | -t] [-e EPD]
+                    [-c CONTRAST] [-C]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -117,6 +117,7 @@ Frame Update Args:
                         advance INCREMENT frames each refresh (default: 4)
   -s START, --start START
                         start playing at a specific frame
+  -F, --fullscreen      expand image to fill display
   -S, --subtitles       display SRT subtitles
   -t, --timecode        display video timecode
 

--- a/slowmovie.py
+++ b/slowmovie.py
@@ -80,9 +80,9 @@ def overlay_filter(self):
 def fullscreen_filter(self):
     if args.fullscreen:
         if videoInfo["aspect_ratio"] > width / height:
-            return self.filter("crop", f"ih*({width / height})", "ih")
+            return self.filter("crop", f"ih*{width / height}", "ih")
         elif videoInfo["aspect_ratio"] < width / height:
-            return self.filter("crop", "iw", f"iw*({height / width})")
+            return self.filter("crop", "iw", f"iw*{height / width}")
     return self
 
 

--- a/slowmovie.py
+++ b/slowmovie.py
@@ -59,6 +59,7 @@ def generate_frame(in_filename, out_filename, time):
         ffmpeg
         .input(in_filename, ss=time)
         .filter("scale", "iw*sar", "ih")
+        .filter("crop", cropwidth, "ih")
         .filter("scale", width, height, force_original_aspect_ratio=1)
         .filter("pad", width, height, -1, -1)
         .overlay_filter()
@@ -230,6 +231,7 @@ argsControl.add_argument("-r", "--random-frames", action="store_true", help="cho
 argsControl.add_argument("-d", "--delay", default=120, type=int, help="delay in seconds between screen updates (default: %(default)s)")
 argsControl.add_argument("-i", "--increment", default=4, type=int, help="advance INCREMENT frames each refresh (default: %(default)s)")
 argsControl.add_argument("-s", "--start", type=int, help="start playing at a specific frame")
+argsControl.add_argument("-F", "--fullscreen", action="store_true", help="expand image to fill display")
 textOverlayGroup = argsControl.add_mutually_exclusive_group()
 textOverlayGroup.add_argument("-S", "--subtitles", action="store_true", help="display SRT subtitles")
 textOverlayGroup.add_argument("-t", "--timecode", action="store_true", help="display video timecode")
@@ -359,6 +361,12 @@ if not args.random_frames:
 
 # Initialize lastVideo so that first time through the loop, we'll print "Playing x"
 lastVideo = None
+
+# Set crop width according to --fullscreen argument
+if args.fullscreen:
+    cropwidth = f"ih*({width/height})"
+else:
+    cropwidth = "iw"
 
 while True:
     if lastVideo != currentVideo:


### PR DESCRIPTION
As suggested by @TomWhitwell, this adds an option (`--fullscreen` or `-F`) to crop the image to the center, eliminating borders.

![frame](https://user-images.githubusercontent.com/4073789/191893076-63238c0f-c18e-47e0-a35d-0a8c4c6067cf.png)
![framecropped](https://user-images.githubusercontent.com/4073789/191893062-b7d01d5b-070e-483a-b184-9846bac89b61.png)