### PR TITLE
Service install Fixes

### DIFF
--- a/Install/install.sh
+++ b/Install/install.sh
@@ -209,8 +209,11 @@ if [ $INSTALL_OPTION -eq 1 ]; then
   # prompt for service install if the first time being run (whiptail 1=No)
   INSTALL_SERVICE=1
   if [ ! -d "${LOCAL_DIR}" ]; then
-    whiptail --yesno "Would you like to install the SlowMovie Service to\nstart playback automatically?" 0 0
-    INSTALL_SERVICE=$?
+    if whiptail --yesno "Would you like to install the SlowMovie Service to\nstart playback automatically?" 0 0; then
+      INSTALL_SERVICE=0
+    else
+      INSTALL_SERVICE=1
+    fi
   fi
 
 	# install or update


### PR DESCRIPTION
These should fix both #140  and #141. 

For the first one the service install process was not working properly as it wasn't generating the service file from the template as expected.  Some reconfiguring of the service install process was done to fix this. I added a `copy_service_file` function to keep all this code in the same spot. The `install_slowmovie` function now calls `install_service` directly when it notices the service is installed during an upgrade. `install_service` now branches to either do a new service install or an upgraded service (if necessary). 

For the second bug I actually found this while trying to fix the first one. When selecting "no" to the service install question the entire script was just closing out instead of continuing properly. I played around with `whiptail` a bunch but it just didn't seem to be returning the variable properly no matter what I did. Storing the result directly using either `$?` or assigning it as part of the call all resulted in the script crashing. Wrapping everything in an `if` statement was the only way I could get it to function. Now the `INSTALL_SERVICE` variable is set based on the yes/no action instead of storing the output of whiptail directly. This worked when testing in all scenarios (selecting yes or no during clean install). 