### PR TITLE
Allow For Waveshare Driver Rollback

### DIFF
--- a/Install/install.sh
+++ b/Install/install.sh
@@ -23,6 +23,14 @@ function install_python_packages(){
   pip3 install -r $LOCAL_DIR/Install/requirements.txt -U
 }
 
+function rollback_waveshare(){
+  # uninstall waveshare lib (installed with omni-epd)
+  pip3 uninstall waveshare-epd
+
+  # install based on specific tagged version known to work with 7.5in displays
+  pip3 install -U "git+https://github.com/waveshare/e-Paper.git@b36cfab0ea336673982640ea21969e5a54714448#subdirectory=RaspberryPi_JetsonNano/python&egg=waveshare-epd"
+}
+
 function setup_hardware(){
   echo "Setting up SPI"
   if ls /dev/spi* &> /dev/null; then
@@ -200,6 +208,7 @@ INSTALL_OPTION=$(whiptail --menu "\
 1 "Install/Upgrade SlowMovie" \
 2 "Install SlowMovie Service" \
 3 "Uninstall SlowMovie Service" \
+4 "Rollback Waveshare Driver" \
 3>&1 1>&2 2>&3)
 
 : ${INSTALL_OPTION:=4}
@@ -230,6 +239,9 @@ elif [ $INSTALL_OPTION -eq 2 ]; then
 elif [ $INSTALL_OPTION -eq 3 ]; then
 	# uninstall the service
   uninstall_service
+elif [ $INSTALL_OPTION -eq 4 ]; then
+  # rollback the waveshare driver (for 7.5in V2 displays)
+  rollback_waveshare
 fi
 
 if [ "${RESTART_SERVICE}" = "TRUE" ] && (service_installed); then

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ SlowMovie is the code that runs a VSMP on a Raspberry Pi.
 
 SlowMovie requires [Python 3](https://www.python.org). It uses [FFmpeg](https://ffmpeg.org) via [ffmpeg-python](https://github.com/kkroening/ffmpeg-python) for video processing, [Pillow](https://python-pillow.org) for image processing, and [Omni-EPD](https://github.com/robweber/omni-epd) for loading the correct e-ink display driver. [ConfigArgParse](https://github.com/bw2/ConfigArgParse) is used for configuration and argument handling.
 
+**Waveshare 7.5in V2 Disclaimer:** There have been [several](https://github.com/TomWhitwell/SlowMovie/issues/143) [reports](https://github.com/TomWhitwell/SlowMovie/issues/134) of streaking issues with the Waveshare 7.5in V2 display (original display used in project) using Waveshare's current driver set. Using the automated install script you can choose to rollback the Waveshare drivers to a known working version for this display. 
+
 ### Automated installation
 
 You can quickly install this repository and all required libraries via an install script. This is a simple way to get started if you're not as comfortable with the command line.


### PR DESCRIPTION
This is an attempt to give end-users more information and options regarding the known streaking issues with some Waveshare displays (notably the 7.5in V2) as described in several issues. 

This PR adds a disclaimer to the README and adds an additional option to the automated installer that will rollback the driver to a known working version. It is worth noting that subsequent runs of the install script will attempt to upgrade the Waveshare drivers since Waveshare doesn't use version numbers as part of their install. Users that need the rollback can re-run the rollback option on update. This allows for the option of always reverting back to the most up to date drivers if needed via the "update" method. 