### PR TITLE
updated omni-epd to version 0.3.4

### DIFF
--- a/Install/requirements.txt
+++ b/Install/requirements.txt
@@ -2,4 +2,4 @@ ffmpeg-python==0.2.0
 Pillow>=9.1.0
 ConfigArgParse==1.4.1
 git+https://github.com/waveshare/e-Paper.git#subdirectory=RaspberryPi_JetsonNano/python&egg=waveshare-epd
-git+https://github.com/robweber/omni-epd.git@v0.3.2#egg=omni-epd
+git+https://github.com/robweber/omni-epd.git@v0.3.4#egg=omni-epd


### PR DESCRIPTION
Bumps omni-epd branch to current version. Summary of changes below. 

## Version 0.3.4

### Added

- `palette_filter` advanced option now supports [color names](https://github.com/python-pillow/Pillow/blob/e3cb4bb8e00fcaf4c3e0783f7c02e51372595659/src/PIL/ImageColor.py#L153-L305) or hex values in addition to RGB colors. Thanks missionfloyd
- IT8951 devices now support `gray16` mode for grayscale
- [Waveshare 10.3 IT8951](https://www.waveshare.com/10.3inch-e-paper-hat.htm) device marked as tested. Thanks simonjowett

## Version 0.3.3

### Added

- added link to [pycasso](https://github.com/jezs00/pycasso) in the README. Thanks jezs00
- new displays, [Waveshare 7.3in 7 Color](https://www.waveshare.com/7.3inch-e-paper-hat-f.htm) - thanks evelyndooley, [Waveshare 2.13in V3](https://www.waveshare.com/2.13inch-e-paper-hat.htm)
