### PR TITLE
Omni-epd 0.4.0 for Bookworm

### DIFF
--- a/Install/requirements.txt
+++ b/Install/requirements.txt
@@ -1,5 +1,4 @@
 ffmpeg-python==0.2.0
 Pillow>=9.1.0
 ConfigArgParse==1.4.1
-git+https://github.com/waveshare/e-Paper.git#subdirectory=RaspberryPi_JetsonNano/python&egg=waveshare-epd
-git+https://github.com/robweber/omni-epd.git@v0.3.4#egg=omni-epd
+git+https://github.com/robweber/omni-epd.git@v0.4.0#egg=omni-epd

--- a/README.md
+++ b/README.md
@@ -6,10 +6,6 @@
 
 Very Slow Movie Player using Python + Raspberry Pi
 
-## Regarding Raspberry Pi OS 12 Bookworm
-
-There are numerous dependency issues with Python 3.11 and [upstream libraries](https://github.com/TomWhitwell/SlowMovie/issues/150) using this project with the latest Raspberry Pi OS (Bookworm). The preferred install method for now is to install the [legacy OS 11 (Bullseye)](https://downloads.raspberrypi.com/raspios_lite_arm64/images/raspios_lite_arm64-2023-05-03/).
-
 ## Table Of Contents
 
 - [Background](#background)

--- a/README.md
+++ b/README.md
@@ -66,19 +66,17 @@ On the Raspberry Pi:
 2. Create & activate python virtual environment (venv)
    * Create virtual environment: `python3 -m venv --system-site-packages .SlowMovie`
    * Activate virtual environment: `source .SlowMovie/bin/activate`
-3. Install Waveshare e-paper drivers
-   * `pip3 install "git+https://github.com/waveshare/e-Paper.git#subdirectory=RaspberryPi_JetsonNano/python&egg=waveshare-epd"`
-4. Clone this repo
+3. Clone this repo
    * `git clone https://github.com/TomWhitwell/SlowMovie`
    * Navigate to the new SlowMovie directory: `cd SlowMovie/`
    * Copy the default configuration file: `cp Install/slowmovie-default.conf slowmovie.conf`
-5. Make sure dependencies are installed
+4. Make sure dependencies are installed - this will install the EPD drivers
    * `sudo apt install ffmpeg`
    * `pip3 install ffmpeg-python`
    * `pip3 install pillow`
    * `pip3 install ConfigArgParse`
    * `pip3 install git+https://github.com/robweber/omni-epd.git#egg=omni-epd`
-6. Test it out
+5. Test it out
    * Run `python3 slowmovie.py`. If everything's installed properly, this should start playing `test.mp4` (a clip from _Psycho_) from the `Videos` directory.
 
 ## Usage
@@ -207,6 +205,7 @@ Please read our [contributing guidelines](/.github/CONTRIBUTING.md) before submi
 * [@missionfloyd](https://github.com/missionfloyd)
 * [@robweber](https://github.com/robweber)
 * [@qubist](https://github.com/qubist)
+* [@JonCellini](https://github.com/JonCellini)
 
 ## License
 


### PR DESCRIPTION
This updates the omni-epd library to the latest version, compatible with Raspberry Pi OS 12 (Bookworm). See the [release details ](https://github.com/robweber/omni-epd/releases/tag/v0.4.0)for a full list of changes. Mostly these incorporate updates to the IT8950 repo and Waveshare packages so they'll run on both Bullseye and Bookworm systems. 

This, coupled with #150 make SlowMovie fully compatible with both Bullseye and Bookworm installs now. I also removed redundant references to install the Waveshare drivers as the current Waveshare repo will not work on Bookworm. Right now a fork is used in omni-epd, which will be reverted back to the official repo once it's compatible. 