### PR TITLE
Update omni-epd to 0.4.1

### DIFF
--- a/Install/requirements.txt
+++ b/Install/requirements.txt
@@ -1,4 +1,4 @@
 ffmpeg-python==0.2.0
 Pillow>=9.1.0
 ConfigArgParse==1.4.1
-git+https://github.com/robweber/omni-epd.git@v0.4.0#egg=omni-epd
+git+https://github.com/robweber/omni-epd.git@v0.4.1#egg=omni-epd


### PR DESCRIPTION
Updates the omni-epd version to the most current. This version reverts the Waveshare repo location back to the official source now that support for Bookworm and Raspberry Pi 5 is in the main branch there. 